### PR TITLE
fix: redirect unit page to login page when have no login info

### DIFF
--- a/src/header/HeaderLearning.jsx
+++ b/src/header/HeaderLearning.jsx
@@ -30,6 +30,13 @@ const HeaderLearning = ({
   //header logo
   const [headerLogoSrc, setHeaderLogoSrc] = useState(getConfig().LOGO_URL);
 
+  useEffect(() => {
+    console.log("authenticatedUser_new_header", authenticatedUser)
+    if (!authenticatedUser) {
+      window.location.href = getConfig().LOGIN_URL;
+    } 
+  }, []);
+
   // useEffect(async()=>{
   //   try {
   //     const {checkSurveyCourse, checkUserSurvey } = await fetchSurveyCourse(courseIdFromUrl)


### PR DESCRIPTION
When a user is in the sign out state but accesses the unit page, the user will be redirected to the login page.
